### PR TITLE
feat(static): add mind map + top link

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,13 @@
     <style>body{font-family:system-ui,-apple-system,'Cairo','Noto Sans Arabic',Tahoma,sans-serif}</style>
   </head>
   <body class="bg-gradient-to-b from-white to-gray-50 text-gray-900">
+    <div id="top-link" style="display:flex;justify-content:flex-start;gap:8px;margin:8px 0;">
+      <a href="./maps/journalist-ai-journey.html" target="_blank" rel="noopener"
+         style="border:1px solid #e2e8f0;background:#fff;border-radius:12px;padding:8px 12px;font-size:13px;text-decoration:none;color:#0f172a">
+        🗺️ خريطة رحلة الصحفي (PDF)
+      </a>
+    </div>
+
     <div id="root"></div>
 
     <script type="text/babel" data-presets="typescript,react">

--- a/maps/journalist-ai-journey.html
+++ b/maps/journalist-ai-journey.html
@@ -5,17 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>رحلة الصحفي في العصر الرقمي مع الذكاء الاصطناعي — خريطة معرفية</title>
 
-    <!-- خط عربي حديث -->
     <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;700&display=swap" rel="stylesheet" />
-
     <style>
       :root { --c1:#0ea5e9; --c2:#14b8a6; --c3:#a855f7; --c4:#f59e0b; }
       html,body{height:100%}
-      body{
-        margin:0; background:linear-gradient(180deg,#fff,#f8fafc);
-        font-family:'Cairo',system-ui,-apple-system,Segoe UI,Roboto,'Noto Sans Arabic',Tahoma,sans-serif;
-        color:#0f172a;
-      }
+      body{ margin:0; background:linear-gradient(180deg,#fff,#f8fafc);
+            font-family:'Cairo',system-ui,-apple-system,Segoe UI,Roboto,'Noto Sans Arabic',Tahoma,sans-serif; color:#0f172a; }
       .wrap{max-width:1100px;margin:0 auto;padding:20px 16px}
       h1.title{font-weight:800;font-size:26px;margin:0 0 8px}
       p.subtitle{margin:0 0 16px;color:#475569}
@@ -24,18 +19,14 @@
       .btn:hover{background:#f8fafc}
       .legend{display:flex;flex-wrap:wrap;gap:8px;margin:6px 0 14px}
       .legend span{font-size:12px;border:1px solid #e2e8f0;border-radius:999px;padding:4px 10px;background:#fff}
-
-      /* Markmap tweaks */
       svg{width:100%;height:calc(100vh - 210px)}
       .markmap text{font-size:14px;direction:rtl}
       .markmap .node circle{ fill:#fff; stroke:#94a3b8; }
       .markmap .link{ stroke:#cbd5e1; }
       .markmap .depth-1 text{ fill:var(--c1); font-weight:700 }
       .markmap .depth-1 .link{ stroke:var(--c1) }
-
       .footer{color:#64748b;font-size:12px;margin-top:8px}
       @media (max-width:640px){ svg{height:70vh} h1.title{font-size:22px} }
-      /* طباعة نظيفة */
       @media print{
         body{background:#fff}
         .toolbar,.legend,.footer{display:none!important}
@@ -45,14 +36,10 @@
         p.subtitle{margin:0 0 8px}
       }
     </style>
-
-    <!-- Markmap -->
     <script src="https://cdn.jsdelivr.net/npm/markmap-autoloader@0.15.7"></script>
-    <!-- PDF (jsPDF + svg2pdf) -->
     <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
     <script src="https://unpkg.com/svg2pdf.js@2.2.1/dist/svg2pdf.min.js"></script>
   </head>
-
   <body>
     <div class="wrap">
       <h1 class="title">رحلة الصحفي في العصر الرقمي مع الذكاء الاصطناعي</h1>
@@ -65,13 +52,9 @@
       </div>
 
       <div class="legend">
-        <span>💡 الانطلاق</span>
-        <span>🧱 التطوير</span>
-        <span>🎨 التعمّق</span>
-        <span>✅ الإخراج</span>
+        <span>💡 الانطلاق</span><span>🧱 التطوير</span><span>🎨 التعمّق</span><span>✅ الإخراج</span>
       </div>
 
-      <!-- Markdown to render as mind map -->
       <pre class="nohighlight"><code class="language-markdown">
 ---
 markmap:
@@ -138,17 +121,11 @@ markmap:
 
     <script>
       const $ = (s,el=document)=>el.querySelector(s);
-
-      // مشاركة الرابط
       $('#btn-share').addEventListener('click', async () => {
         try { await navigator.clipboard.writeText(location.href); alert('تم نسخ الرابط'); }
         catch { alert('انسخ الرابط يدويًا من شريط العنوان'); }
       });
-
-      // طباعة (PDF عبر الطباعة)
       $('#btn-print').addEventListener('click', () => window.print());
-
-      // تصدير PDF (jsPDF + svg2pdf)
       async function exportPDF(){
         const ensureSvg = () => new Promise(resolve=>{
           const tick=()=>{ const svg=$('svg'); if(svg) return resolve(svg); setTimeout(tick,120); }; tick();


### PR DESCRIPTION
## Summary
- add stand-alone journalist mind map at `maps/journalist-ai-journey.html`
- expose map via a new top link above the app root
- include `.nojekyll` to serve static files on GitHub Pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa6afc2b4832bada6236dbef9e008