### PR TITLE
feat(poster): add A2 “ChatGPT Brainstorm” poster + link in posters index

### DIFF
--- a/posters/chatgpt-brainstorm-a2.html
+++ b/posters/chatgpt-brainstorm-a2.html
@@ -1,0 +1,255 @@
+<!doctype html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>كيف تستخدم ChatGPT للعصف الذهني؟ — بوستر A2</title>
+  <meta name="description" content="بوستر A2 احترافي: الأطر السبعة للعصف الذهني مع أمثلة صحفية وبرومبتات جاهزة. قابل للطباعة وتصدير PDF.">
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;700;800;900&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root{
+      /* الهوية اللونية المطلوبة */
+      --indigo:#0b1437;              /* خلفية عليا داكنة */
+      --sky:#0ea5e9;                 /* أزرق سماوي */
+      --violet:#8b5cf6;              /* بنفسجي فاتح */
+      --orange:#f59e0b;              /* برتقالي دافئ */
+      --turq:#10b981;                /* أخضر تركوازي */
+      --gray:#e5e7eb;                /* رمادي فاتح للشروح */
+      --row1: linear-gradient(90deg, #0ea5e920, #8b5cf620);
+      --row2: linear-gradient(90deg, #10b98120, #0ea5e920);
+      --row3: linear-gradient(90deg, #f59e0b20, #8b5cf620);
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    body{font-family:'Cairo',system-ui,-apple-system,'Noto Sans Arabic',Segoe UI,Roboto,Tahoma,sans-serif;background:#fff;color:#0f172a}
+
+    /* مساحة البوستر A2 */
+    .sheet{width:420mm; height:594mm; margin:10mm auto;
+      background: linear-gradient(180deg,var(--indigo),#eaf4ff 75%, #ffffff 100%);
+      border-radius:22px; overflow:hidden; position:relative;
+      box-shadow:0 20px 60px rgba(2,6,23,.15);
+    }
+    .pad{padding:16mm}
+
+    /* شريط أدوات علوي للطباعة/التصدير */
+    .toolbar{position:sticky; top:0; z-index:50; background:rgba(255,255,255,.75); backdrop-filter:blur(8px); border-bottom:1px solid #e5e7eb}
+    .btn{border:1px solid #e5e7eb; background:#fff; border-radius:999px; padding:.55rem .9rem; font-size:.9rem}
+    .btn:hover{background:#f8fafc}
+
+    /* العنوان الرئيسي */
+    .hero{position:relative; text-align:center; padding-top:18mm; padding-bottom:10mm; color:#fff}
+    .hero h1{font-weight:900; letter-spacing:.2px; font-size:28pt; text-shadow:0 0 14px rgba(255,255,255,.25);}
+    .hero p{max-width:180mm; margin:4mm auto 0; color:#e6efff}
+    .brain{position:absolute; inset-inline-start:10mm; top:8mm; opacity:.22}
+    .brain svg{width:60mm; height:60mm}
+
+    /* شبكة 3×3 (نستخدم 6 أعمدة لمزيد من المرونة) */
+    .grid-areas{display:grid; grid-template-columns:repeat(6, 1fr); grid-auto-rows:1fr; gap:6mm}
+    /* صفوف ملونة خفيفة */
+    .row{position:relative}
+    .row::before{content:""; position:absolute; inset: -3mm 0 -3mm 0; background:var(--row1); border-radius:18px; z-index:0}
+    .row.middle::before{background:var(--row2)}
+    .row.bottom::before{background:var(--row3)}
+    .row > *{position:relative; z-index:1}
+
+    /* بطاقة إطار */
+    .card{background:#ffffff; border:1px solid #e5e7eb; border-radius:16px; padding:6mm; box-shadow:0 10px 28px rgba(2,6,23,.08)}
+    .card h3{font-size:14pt; font-weight:800; margin:0 0 2mm}
+    .meta{display:flex; align-items:center; gap:3mm; margin-bottom:2mm}
+    .num{display:grid; place-items:center; width:9mm; height:9mm; border-radius:999px; color:#fff; font-weight:800}
+    .desc{font-size:10.5pt; color:#334155}
+    .icon{font-size:14pt}
+    .prompt{margin-top:3mm; border-radius:12px; background:#0b143705; border:1px dashed #94a3b8; padding:4mm}
+    .prompt-title{font-weight:800; font-size:10pt; color:#0b1437; margin-bottom:1.5mm}
+    .prompt pre{white-space:pre-wrap; font: 600 10pt ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace; color:#111827}
+
+    /* ألوان الأطر */
+    .c1{--main: var(--sky)} .c2{--main: var(--violet)} .c3{--main: var(--orange)}
+    .c4{--main: var(--turq)} .c5{--main: #7c3aed} .c6{--main:#475569} .c7{--main:#f59e0b}
+    .num{background:var(--main)}
+    .badge{display:inline-block; border:1px solid #e5e7eb; border-radius:999px; padding:.5mm 2.5mm; font-size:9pt; color:#334155; background:#fff; margin-inline-start:2mm}
+
+    /* فوتر */
+    .footer{margin-top:6mm; background:linear-gradient(180deg,#3b1d72,#4c28a6); color:#fff; border-radius:16px; padding:4mm 6mm; text-align:center; box-shadow:inset 0 18px 40px rgba(255,255,255,.08)}
+    .footer small{opacity:.9}
+
+    /* الطباعة */
+    @page{ size:A2 portrait; margin:10mm }
+    @media print{
+      .toolbar{display:none !important}
+      .sheet{margin:0; border-radius:0; box-shadow:none}
+      .hero h1{text-shadow:none}
+    }
+
+    /* شاشات أصغر (معاينة) */
+    @media (max-width:1200px){
+      .sheet{width:100%; height:auto}
+    }
+  </style>
+</head>
+<body>
+  <!-- أدوات -->
+  <div class="toolbar no-print">
+    <div class="mx-auto max-w-7xl px-4 py-2 flex items-center gap-2">
+      <a href="../index.html" class="btn">⬅️ رجوع</a>
+      <button onclick="window.print()" class="btn">🖨️ طباعة / PDF</button>
+      <button id="btnPdf" class="btn">⬇️ تصدير PDF</button>
+      <span class="ms-auto text-sm text-slate-600">A2 • 3×3 Grid • RTL</span>
+    </div>
+  </div>
+
+  <!-- البوستر -->
+  <main class="sheet">
+    <header class="hero pad">
+      <div class="brain" aria-hidden="true">
+        <!-- أيقونة دماغ بخطوط متصلة -->
+        <svg viewBox="0 0 256 256" fill="none">
+          <defs>
+            <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#0ea5e9"/><stop offset="50%" stop-color="#8b5cf6"/><stop offset="100%" stop-color="#f59e0b"/>
+            </linearGradient>
+          </defs>
+          <path d="M88 80c-20 0-36 16-36 36 0 12 6 22 16 29m16-65c0-18 14-32 32-32s32 14 32 32m-32-32c0-18 14-32 32-32" stroke="url(#g)" stroke-width="6" stroke-linecap="round"/>
+          <circle cx="70" cy="116" r="6" fill="#0ea5e9"/><circle cx="92" cy="88" r="6" fill="#8b5cf6"/>
+          <circle cx="128" cy="60" r="6" fill="#f59e0b"/><circle cx="160" cy="80" r="6" fill="#10b981"/>
+          <circle cx="172" cy="120" r="6" fill="#0ea5e9"/>
+          <path d="M70 116c12 8 22 16 34 28 18 18 34 26 54 28" stroke="url(#g)" stroke-width="6" stroke-linecap="round"/>
+        </svg>
+      </div>
+      <h1>كيف تستخدم ChatGPT للعصف الذهني؟</h1>
+      <p>العصف الذهني ليس إلهامًا عابرًا؛ بل عملية يمكن إدارتها. هذه الأطر السبعة تمنحك خطوات عملية + برومبتات جاهزة لتوليد أفكار صحفية بسرعة ثم تنقيتها وتطويرها.</p>
+    </header>
+
+    <section class="pad grid-areas">
+      <!-- ===== الصف العلوي: 3 بطاقات ===== -->
+      <div class="row" style="grid-column:1/-1; grid-row:1">
+        <div class="card c1" style="grid-column:1/3;">
+          <div class="meta"><span class="num">1</span><h3>الأطر الكلاسيكية (Frameworks)</h3><span class="badge">مكعب ◽︎</span></div>
+          <div class="desc">
+            5 Whys, SCAMPER, قبعات التفكير الست، خرائط ذهنية، Starbursting. استخدم الإطار الأنسب لتعميق الفكرة سريعًا.
+            <ul class="list-disc pr-4 mt-2 text-slate-700">
+              <li><b>مثال صحفي:</b> «لماذا ينصرف القرّاء عن التغطية المحلية؟» → سلسلة لماذا حتى الجذر: نقص شبكة المصادر.</li>
+            </ul>
+          </div>
+          <div class="prompt">
+            <div class="prompt-title">💬 قالب برومبت (اختر الإطار):</div>
+<pre>حلّل موضوع: [العنوان] باستخدام أحد الأطر (5Whys/SCAMPER/قبعات/خريطة/Starbursting).
+- لِـ5Whys: قدّم سلسلة "لماذا → لأن" حتى السبب الجذري + 3 حلول خلال أسبوعين.
+- لِـSCAMPER: فكرتان لكل حرف مع وصف التنفيذ الصحفي.</pre>
+          </div>
+        </div>
+
+        <div class="card c2" style="grid-column:3/5;">
+          <div class="meta"><span class="num">2</span><h3>وجهات نظر مختلفة (Different Perspectives)</h3><span class="badge">👥</span></div>
+          <div class="desc">
+            انظر للموضوع بأدوار: محرّر، مراسل ميداني، محلّل بيانات، قارئ متشكّك، خبير أخلاقيات.
+            <ul class="list-disc pr-4 mt-2 text-slate-700"><li><b>مثال:</b> أزمة مياه مدينة صغيرة من منظور كل دور → زوايا تحقيق متعددة.</li></ul>
+          </div>
+          <div class="prompt">
+            <div class="prompt-title">💬 برومبت جاهز:</div>
+<pre>نخطط لتغطية: [موضوع]. تصرّف كـ(محرر ← مراسل ← محلّل بيانات ← قارئ ← خبير أخلاقيات).
+لكل دور: 8 أسئلة/مخاوف وزاويتان تحقيق قصصي. ادمج المتكرر واقترح 5 زوايا نهائية.</pre>
+          </div>
+        </div>
+
+        <div class="card c3" style="grid-column:5/7;">
+          <div class="meta"><span class="num">3</span><h3>يوم العكس (Opposite Day)</h3><span class="badge">↔︎</span></div>
+          <div class="desc">
+            فكّر بما يجعل التجربة أسوأ… ثم اعكسه إلى إجراءات تحسين.
+            <ul class="list-disc pr-4 mt-2 text-slate-700"><li><b>مثال:</b> الملل؟ → عناوين دقيقة + تقسيم فقرات + مخططات سريعة.</li></ul>
+          </div>
+          <div class="prompt">
+            <div class="prompt-title">💬 برومبت جاهز:</div>
+<pre>أعطني 15 طريقة قد تجعل [الجمهور] غير راضٍ عن [المحتوى].
+اعكس كل نقطة إلى إجراء عملي، ثم رتّبها وفق (الأثر × الجهد) مع توصية أول 5 إجراءات.</pre>
+          </div>
+        </div>
+      </div>
+
+      <!-- ===== الصف الأوسط: بطاقتان واسعتان ===== -->
+      <div class="row middle" style="grid-column:1/-1; grid-row:2;">
+        <div class="card c4" style="grid-column:1/4;">
+          <div class="meta"><span class="num">4</span><h3>خطوة بخطوة (Step-by-Step)</h3><span class="badge">سلم ⤴︎</span></div>
+          <div class="desc">
+            سير عمل صحفي: موضوع عام → محاور فرعية → أسئلة مفتاحية → مصادر/بيانات → زوايا → عناوين/خطّاف → خطة إنتاج.
+          </div>
+          <div class="prompt">
+            <div class="prompt-title">💬 برومبت متسلسل (انسخه على مراحل):</div>
+<pre>اذكر 12 محورًا فرعيًا لموضوع: [موضوع].
+لكل محور: 3 أسئلة تحقيقيّة قابلة للإجابة ومصادر/بيانات علنية.
+استخرج 10 زوايا قصصية، ثم 6 عناوين وخطّاف لكل زاوية.
+صِغ خطة إنتاج أسبوعين: (مهمة/مسؤول/موعد/مؤشر نجاح).</pre>
+          </div>
+        </div>
+
+        <div class="card c5" style="grid-column:4/7;">
+          <div class="meta"><span class="num">5</span><h3>الكلمات الإبداعية (Creative Words)</h3><span class="badge">📣</span></div>
+          <div class="desc">
+            اختر كلمة موجِّهة واحدة لكل جلسة: غير متوقَّع، بديل جريء، إنسانيّ النزعة، غير مُتحيز…
+          </div>
+          <div class="prompt">
+            <div class="prompt-title">💬 أمثلة جاهزة:</div>
+<pre>• أعطني 12 فكرة <غير متوقعة> لتغطية [موضوع].
+• اقترح 10 زوايا <إنسانية بعمق> لملف [موضوع] مع مصادر محتملة.
+• أعد صياغة 5 عناوين بأسلوب متميز وقابل للمشاركة (دون تهويل).</pre>
+          </div>
+        </div>
+      </div>
+
+      <!-- ===== الصف السفلي: بطاقتان ===== -->
+      <div class="row bottom" style="grid-column:1/-1; grid-row:3;">
+        <div class="card c6" style="grid-column:1/4;">
+          <div class="meta"><span class="num">6</span><h3>سلسلة الكثافة (Chain of Density)</h3><span class="badge">⛓︎</span></div>
+          <div class="desc">
+            دورات قصيرة لإضافة زوايا/معلومات ناقصة مع الحفاظ على الإيجاز في كل دورة.
+          </div>
+          <div class="prompt">
+            <div class="prompt-title">💬 برومبت شامل:</div>
+<pre>سنجري سلسلة كثافة حول [موضوع]:
+1) اكتب 10 أفكار أساسية.
+2) حدد 3 فجوات مهمة.
+3) أعد الكتابة بإضافة الفجوات من دون زيادة الطول.
+كرر 5 مرات وقدّم النسخة النهائية مع ملاحظات التحسين.</pre>
+          </div>
+        </div>
+
+        <div class="card c7" style="grid-column:4/7;">
+          <div class="meta"><span class="num">7</span><h3>التفكير بالمبادئ الأولى (First Principles)</h3><span class="badge">◿ مكعب</span></div>
+          <div class="desc">
+            فكّك المشكلة إلى حقائق أولية لا جدال فيها، وافصلها عن الافتراضات؛ ثم أعد التركيب من الصفر.
+          </div>
+          <div class="prompt">
+            <div class="prompt-title">💬 برومبت جاهز:</div>
+<pre>طبّق مبادئ أولى على: [تحدّي].
+اعرض: الهدف، الحقائق المؤكدة، الافتراضات، القيود.
+اقترح 3 حلول مبنية فقط على الحقائق مع خطة اختبار أسبوع واحد ومقاييس نجاح.</pre>
+          </div>
+        </div>
+      </div>
+
+      <!-- فوتر -->
+      <div class="footer" style="grid-column:1/-1;">
+        <div class="text-base font-bold">استخدم هذه الأطر لتفكير أعمق، أفكار أوسع، وإبداع بلا حدود مع ChatGPT.</div>
+        <small class="block mt-1">✏️ 💡 💻</small>
+      </div>
+    </section>
+  </main>
+
+  <!-- تصدير PDF (A2) -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
+  <script>
+    document.getElementById('btnPdf').addEventListener('click', () => {
+      const el = document.querySelector('.sheet');
+      const opt = {
+        margin: [10,10,10,10],
+        filename: 'chatgpt-brainstorm-a2.pdf',
+        image: { type: 'jpeg', quality: 0.98 },
+        html2canvas: { scale: 2, useCORS: true },
+        jsPDF: { unit: 'mm', format: 'a2', orientation: 'portrait' }
+      };
+      html2pdf().set(opt).from(el).save();
+    });
+  </script>
+</body>
+</html>

--- a/posters/index.html
+++ b/posters/index.html
@@ -35,6 +35,12 @@
           <p class="mt-1 text-sm text-slate-600">بوستر رأسي جاهز للطباعة A3 + زر طباعة/حفظ PDF ووضع داكن.</p>
           <span class="mt-3 inline-block text-sm text-violet-700 group-hover:underline">افتح البوستر →</span>
         </a>
+          <a href="./chatgpt-brainstorm-a2.html" class="group rounded-2xl border bg-white p-5 hover:shadow transition">
+          <div class="text-3xl">🧠✨</div>
+          <h2 class="mt-2 text-lg font-bold">كيف تستخدم ChatGPT للعصف الذهني؟ — بوستر A2</h2>
+          <p class="mt-1 text-sm text-slate-600">الأطر السبعة + أمثلة صحفية + برومبتات جاهزة، طباعة/تصدير PDF.</p>
+          <span class="mt-3 inline-block text-sm text-indigo-700 group-hover:underline">افتح البوستر →</span>
+        </a>
         <!-- أضف بوسترات أخرى لاحقًا بنفس النمط -->
     </div>
   </main>


### PR DESCRIPTION
## Summary
- add new A2 poster page for ChatGPT brainstorming with seven frameworks, examples, and ready prompts
- link the ChatGPT Brainstorm poster from the posters index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac14dda0c8832b81d8cf3f2875e37b