### PR TITLE
feat: add self-contained poster with dynamic export

### DIFF
--- a/posters/5-super-prompts.html
+++ b/posters/5-super-prompts.html
@@ -19,12 +19,12 @@
     }
     html, body {height:100%}
     body {font-family: 'Cairo', 'Tajawal', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; background: var(--bg-gradient); color: var(--text-color);}    
+    *, *::before, *::after { box-sizing: border-box; }
     .card {background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); backdrop-filter: blur(10px); box-shadow: 0 8px 30px rgba(0,0,0,0.3); transition: transform 0.3s ease, box-shadow 0.3s ease;}
     .card:hover {transform: translateY(-6px); box-shadow: 0 12px 40px rgba(0,0,0,0.5);}    
-    .glow-title {text-shadow: 0 0 10px rgba(255,212,77,.7), 0 0 20px rgba(255,212,77,.5);}
+    .glow-title {text-shadow: 0 0 10px rgba(255,212,77,.7), 0 0 20px rgba(255,212,77,.5);}    
     /* Canvas sized artboard for pixel-perfect PNG (1080x1350) */
     #poster {width:1080px; height:1350px; box-sizing:border-box; overflow:visible;}
-    *, *::before, *::after { box-sizing: border-box; }
   </style>
 </head>
 <body class="min-h-screen flex flex-col items-center p-4">
@@ -41,13 +41,13 @@
   <!-- Artboard -->
   <main id="poster" class="mx-auto flex flex-col items-center p-8 rounded-[28px]" style="background: var(--bg-gradient); color: var(--text-color);">
     <!-- Header -->
-    <header class="text-center mb-12">
+    <header class="text-center mb-8">
       <h1 class="text-5xl md:text-6xl font-extrabold glow-title" style="color: var(--title-color)">5 برومبتات خارقة لتفجير طاقتك وتخطي عقباتك الذهنية</h1>
       <p class="mt-4 max-w-2xl mx-auto text-lg opacity-90">باستخدام الذكاء الاصطناعي كمدرب شخصي، ستواجه ذاتك، تعيد كتابة أخطائك كحوافز، تبني انضباطًا حديديًا، وتسمع الحقيقة من نسخة نفسك المستقبلية.</p>
     </header>
 
     <!-- Prompts -->
-    <section class="grid grid-cols-1 gap-8 max-w-3xl w-full">
+    <section class="grid grid-cols-1 gap-6 max-w-3xl w-full">
       <!-- Prompt 1 -->
       <div class="card p-6 rounded-2xl">
         <div class="flex items-center gap-4 mb-3">
@@ -63,7 +63,7 @@
           <span class="text-4xl" style="color: var(--icon-color)">🚀</span>
           <h3 class="text-2xl font-bold" style="color: var(--highlight)">تحويل الفشل إلى دافع</h3>
         </div>
-        <p class="text-base leading-relaxed">"تصرّف كمدرّ للنمو الشخصي. اسألني 6 أسئلة لفهم أسباب فشلي في الموقف أو المشروع. بعد ذلك، أعد صياغة الفشل كحقيقة محفّزة، وقدّم لي خطة مختصرة من 3 خطوات عملية لتحويل التجربة إلى طاقة إيجابية تدفعني للأمام."</p>
+        <p class="text-base leading-relaxed">"تصرّف كمدرّب للنمو الشخصي. اسألني 6 أسئلة لفهم أسباب فشلي في الموقف أو المشروع. بعد ذلك، أعد صياغة الفشل كحقيقة محفّزة، وقدّم لي خطة مختصرة من 3 خطوات عملية لتحويل التجربة إلى طاقة إيجابية تدفعني للأمام."</p>
       </div>
 
       <!-- Prompt 3 -->
@@ -95,7 +95,7 @@
     </section>
 
     <!-- Tips -->
-    <section class="mt-12 max-w-3xl text-center space-y-3">
+    <section class="mt-8 max-w-3xl text-center space-y-3">
       <h2 class="text-2xl font-bold" style="color: var(--title-color)">نصائح لاستخدام البرومبتات بفعالية 🎯</h2>
       <p class="text-base opacity-90">كن صريحًا مع نفسك: كلما كنت أكثر تحديدًا في إدخال تفاصيل مشاكلك، حصلت على نتائج أدق.</p>
       <p class="text-base opacity-90">اطلب خططًا عملية: لا تكتفِ بالنصائح؛ اطلب خطوات وجداول زمنية.</p>
@@ -103,120 +103,93 @@
       <p class="text-base opacity-90">ادمجها مع أدواتك اليومية: يمكنك ربط هذه البرومبتات مع تطبيقات الذكاء الاصطناعي لتتبع التقدم وتنظيم الأهداف.</p>
     </section>
 
-    <!-- Footer -->
-    <footer class="mt-12 text-center space-y-4">
+    <!-- Footer with QR (inline SVG generated at runtime for export safety) -->
+    <footer class="mt-8 text-center space-y-3">
       <div class="text-lg font-semibold" style="color: var(--title-color)">الذكاء الاصطناعي لتفجير طاقتك وتعزيز إبداعك</div>
       <div>
-        <!-- قد يسبب هذا المصدر الخارجي مشكلة CORS أثناء التصدير، لذا نعلّمه كغير آمن ويمكن إخفاؤه تلقائيًا إذا فشل التصدير. -->
-        <img data-export-safe="false" crossorigin="anonymous" src="https://api.qrserver.com/v1/create-qr-code/?data=https://mohasharif.github.io/Philomoha/&size=120x120" alt="QR Code" class="mx-auto mt-2 shadow-md rounded-xl">
+        <img id="qrImg" alt="QR Code" class="mx-auto mt-2 shadow-md rounded-xl" width="120" height="120"/>
         <p class="mt-2 text-sm opacity-80">امسح الكود للوصول إلى المزيد من الموارد</p>
       </div>
     </footer>
-
-    <!-- Hidden small test card for exporter self-test -->
-    <div id="testCard" class="card p-4 rounded-2xl mt-8 max-w-xs text-center hidden">
-      <div class="text-xl font-bold" style="color:var(--title-color)">بطاقة اختبار</div>
-      <div class="mt-1 text-sm" style="color:var(--highlight)">يجب أن تظهر هذه البطاقة بنفس الأسلوب عند التصدير</div>
-    </div>
   </main>
 
-  <!-- Export logic with robust fallbacks and tests -->
+  <!-- Export logic: dom-to-image-more with dynamic loader + QR inline SVG -->
   <script>
-    // Dynamic loader helper
+    // Dynamic loader for export libs & QR
     function loadScript(src){
-      return new Promise((resolve,reject)=>{
-        const s=document.createElement('script');
-        s.src=src; s.async=true; s.onload=()=>resolve(true); s.onerror=()=>reject(new Error('Failed to load '+src));
-        document.head.appendChild(s);
-      });
+      return new Promise((resolve,reject)=>{ const s=document.createElement('script'); s.src=src; s.async=true; s.onload=()=>resolve(true); s.onerror=()=>reject(new Error('load fail '+src)); document.head.appendChild(s); });
     }
 
-    async function ensureExporter(){
-      const statusEl = document.getElementById('libStatus');
-      if(window.htmlToImage){ statusEl.textContent = 'المحرّك: html-to-image (جاهز)'; return 'html-to-image'; }
-      // Try jsDelivr first (بعض البيئات تحظر unpkg)
-      try{ await loadScript('https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.min.js'); }
-      catch(e){ /* ignore */ }
-      if(window.htmlToImage){ statusEl.textContent = 'المحرّك: html-to-image من jsDelivr'; return 'html-to-image'; }
+    async function ensureDomToImage(){
+      const st = document.getElementById('libStatus');
+      if(window.domtoimage){ st.textContent='المحرّك: dom-to-image-more (جاهز)'; return 'dom-to-image-more'; }
+      try{ await loadScript('https://cdn.jsdelivr.net/npm/dom-to-image-more@3.4.0/dist/dom-to-image-more.min.js'); }
+      catch(e){ try{ await loadScript('https://unpkg.com/dom-to-image-more@3.4.0/dist/dom-to-image-more.min.js'); }catch(_){} }
+      if(window.domtoimage){ st.textContent='المحرّك: dom-to-image-more'; return 'dom-to-image-more'; }
       // Fallback to html2canvas
-      if(window.html2canvas){ statusEl.textContent = 'المحرّك: html2canvas (جاهز)'; return 'html2canvas'; }
-      try{ await loadScript('https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js'); }
-      catch(e){ /* ignore */ }
-      if(window.html2canvas){ statusEl.textContent = 'المحرّك: html2canvas من CDNJS'; return 'html2canvas'; }
-      statusEl.textContent = 'المحرّك: غير متوفر — تعذّر تحميل المكتبات';
-      throw new Error('Exporter library unavailable');
+      if(!window.html2canvas){ try{ await loadScript('https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js'); }catch(e){} }
+      if(window.html2canvas){ st.textContent='المحرّك: html2canvas (بديل)'; return 'html2canvas'; }
+      st.textContent='المحرّك: غير متوفر'; throw new Error('no exporter');
     }
 
-      async function exportAs(type){
-        const poster = document.getElementById('poster');
-        const statusEl = document.getElementById('libStatus');
-        const btn = type==='png' ? document.getElementById('downloadPng') : document.getElementById('downloadJpg');
-        btn.disabled = true; const old = btn.textContent; btn.textContent = '⏳ جارٍ التصدير…';
-        try{
-          const engine = await ensureExporter();
-          let dataUrl;
-          if(engine==='html-to-image'){
-            try{
-              dataUrl = await (async ()=>{ const ratio=3, targetW=1080, targetH=1350; 
-            let dataUrl = await window.htmlToImage.toPng(poster, { pixelRatio: ratio, cacheBust: true, width: targetW, height: targetH, style:{transform:'none'} });
-            await new Promise((res)=>{ const img=new Image(); img.onload=()=>res(img); img.src=dataUrl; }).then(img=>{ if(img.naturalWidth!==targetW*ratio || img.naturalHeight!==targetH*ratio){ throw new Error('Dimension mismatch'); } });
-            window.__EXPORTED_URL__ = dataUrl; })();
-            }catch(e){
-              console.warn('html-to-image failed, falling back to html2canvas', e);
-            }
-          }
-          if(!dataUrl){
-            // Fallback to html2canvas, handle possible CORS by temporarily hiding unsafe externals
-            const hide = [];
-            poster.querySelectorAll('[data-export-safe="false"]').forEach(el=>{ hide.push([el, el.style.visibility]); el.style.visibility='hidden'; });
-            const rect2 = poster.getBoundingClientRect();
-            const canvas = await window.html2canvas(poster, {scale:3, useCORS:true, backgroundColor:null, width:1080, height:1350, scrollX:0, scrollY:0, windowWidth: Math.max(1080, Math.ceil(rect2.width)), windowHeight: Math.max(1350, Math.ceil(rect2.height))});
-            hide.forEach(([el,v])=>{ el.style.visibility=v; });
-            dataUrl = (type==='jpg') ? canvas.toDataURL('image/jpeg', 0.95) : canvas.toDataURL('image/png');
-          }
-          const a = document.createElement('a');
-          a.download = type==='jpg' ? 'poster-ai-prompts.jpg' : 'poster-ai-prompts.png';
-          a.href = dataUrl; a.click();
-          statusEl.textContent = 'تم التصدير بنجاح';
-        }catch(err){
-          console.error(err);
-          alert('تعذّر إنشاء الصورة تلقائيًا. إن استمرت المشكلة أخبرني لأرسل لك بديلاً.');
-        }finally{
-          btn.disabled = false; btn.textContent = old;
-        }
-      }
+    // Build QR as inline SVG data URL to avoid CORS
+    async function ensureQR(){
+      if(window.qrcode) return true;
+      try{ await loadScript('https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js'); }
+      catch(e){ try{ await loadScript('https://unpkg.com/qrcode-generator@1.4.4/qrcode.min.js'); }catch(_){} }
+      return !!window.qrcode;
+    }
 
-    // Self tests
-    async function runSelfTest(){
-      const statusEl = document.getElementById('libStatus');
+    async function renderQR(){
+      const ok = await ensureQR();
+      const img = document.getElementById('qrImg');
+      const url = 'https://mohasharif.github.io/Philomoha/';
+      if(!ok){ img.alt='QR غير متاح حالياً'; return; }
+      var qr = qrcode(0,'M');
+      qr.addData(url); qr.make();
+      var svg = qr.createSvgTag({cellSize:2, margin:0});
+      svg = svg.replace(/width="\d+"/,'width="120"').replace(/height="\d+"/,'height="120"');
+      img.src = 'data:image/svg+xml;utf8,' + encodeURIComponent(svg);
+    }
+
+    async function exportAs(type){
+      const poster = document.getElementById('poster');
+      const st = document.getElementById('libStatus');
+      const btn = type==='png' ? document.getElementById('downloadPng') : document.getElementById('downloadJpg');
+      btn.disabled=true; const old=btn.textContent; btn.textContent='⏳ جارٍ التصدير…';
       try{
-        const engine = await ensureExporter();
-        statusEl.textContent = 'اختبار: المحرك المستخدم — ' + engine;
-        // Create a tiny sample export
-        const card = document.getElementById('testCard');
-        card.classList.remove('hidden');
-        if(engine==='html-to-image'){
-          const dataUrl = await window.htmlToImage.toPng(card, {pixelRatio:2, cacheBust:true});
-          if(!dataUrl.startsWith('data:image/png')) throw new Error('Sample export failed');
+        const engine = await ensureDomToImage();
+        let dataUrl;
+        if(engine==='dom-to-image-more'){
+          dataUrl = await window.domtoimage.toPng(poster, { width:1080, height:1350, cacheBust:true, quality:1, style:{transform:'none'} });
+          if(type==='jpg'){
+            const img = new Image(); await new Promise(r=>{ img.onload=r; img.src=dataUrl; });
+            const cnv=document.createElement('canvas'); cnv.width=1080; cnv.height=1350; const ctx=cnv.getContext('2d');
+            ctx.fillStyle='#0A0F29'; ctx.fillRect(0,0,cnv.width,cnv.height); ctx.drawImage(img,0,0);
+            dataUrl = cnv.toDataURL('image/jpeg', 0.95);
+          }
         } else {
-          const canvas = await window.html2canvas(card, {scale:2, useCORS:true, backgroundColor:null});
-          const dataUrl = canvas.toDataURL('image/png');
-          if(!dataUrl.startsWith('data:image/png')) throw new Error('Sample export failed');
+          const rect = poster.getBoundingClientRect();
+          const canvas = await window.html2canvas(poster, {scale:3, useCORS:true, backgroundColor:null, width:1080, height:1350, scrollX:0, scrollY:0, windowWidth: Math.max(1080, Math.ceil(rect.width)), windowHeight: Math.max(1350, Math.ceil(rect.height))});
+          dataUrl = (type==='jpg') ? canvas.toDataURL('image/jpeg',0.95) : canvas.toDataURL('image/png');
         }
-        statusEl.textContent += ' — ✅ نجح اختبار العينة';
-        card.classList.add('hidden');
-      }catch(e){
-        console.error(e);
-        statusEl.textContent = '❌ فشل الاختبار: ' + (e.message||e);
-      }
+        const a=document.createElement('a'); a.download = type==='jpg'?'poster-ai-prompts.jpg':'poster-ai-prompts.png'; a.href=dataUrl; a.click(); st.textContent='تم التصدير بنجاح';
+      }catch(e){ console.error(e); alert('تعذّر إنشاء الصورة تلقائيًا.'); }
+      finally{ btn.disabled=false; btn.textContent=old; }
+    }
+
+    async function runSelfTest(){
+      const st = document.getElementById('libStatus');
+      try{ const engine = await ensureDomToImage(); st.textContent = 'اختبار: ' + engine + ' ✅'; }
+      catch(e){ st.textContent = 'اختبار فشل'; }
     }
 
     document.getElementById('downloadPng').addEventListener('click', ()=>exportAs('png'));
     document.getElementById('downloadJpg').addEventListener('click', ()=>exportAs('jpg'));
     document.getElementById('selfTest').addEventListener('click', runSelfTest);
 
-    // Initial probe
-    (async()=>{ try{ await ensureExporter(); }catch(e){} })();
+    // Init
+    renderQR(); ensureDomToImage().catch(()=>{});
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- simplify poster script with dynamic loader using dom-to-image-more and html2canvas fallback
- render QR code inline to avoid CORS issues

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad78f33488832b8dd083afd0f8afe3