### PR TITLE
Refactor classic brainstorming frameworks section

### DIFF
--- a/posters/chatgpt-brainstorm-a2.html
+++ b/posters/chatgpt-brainstorm-a2.html
@@ -22,6 +22,8 @@ summary:hover .anchor{visibility:visible;}
 .desc{padding:0 1rem 1rem;}
 .prompt{position:relative;margin:0 1rem 1rem;border:1px dashed #94a3b8;border-radius:8px;background:#f8fafc;padding:1rem;}
 .copy{position:absolute;top:.5rem;left:.5rem;font-size:.8rem;border:1px solid #cbd5e1;background:#fff;border-radius:4px;padding:.2rem .5rem;cursor:pointer;}
+.copy-btn{border:1px solid #cbd5e1;background:#fff;border-radius:4px;padding:.2rem .5rem;font-size:.8rem;cursor:pointer;}
+.prompt-box{display:none;}
 .footer{text-align:center;margin-top:2rem;color:#334155;}
 </style>
 </head>
@@ -38,49 +40,70 @@ summary:hover .anchor{visibility:visible;}
 <section class="sec" id="s1">
 <details>
 <summary><span class="num">1</span> الأطر الكلاسيكية (Frameworks) <a class="anchor" href="#s1">#</a></summary>
-<div class="desc">
-5 Whys, SCAMPER, قبعات التفكير الست، خرائط ذهنية، Starbursting. اختر الإطار الأنسب لتعميق الفكرة سريعًا.
-<ul><li><b>مثال صحفي:</b> «لماذا ينصرف القرّاء عن التغطية المحلية؟» → السبب الجذري: نقص شبكة المصادر.</li></ul>
-</div>
-<div class="prompt" id="p-1"><button class="copy" data-copy="p-1">نسخ البرومبت</button><pre>حلّل موضوع: [العنوان] باستخدام أحد الأطر (5Whys/SCAMPER/قبعات/خريطة/Starbursting).
-- 5Whys: "لماذا → لأن" حتى السبب الجذري + 3 حلول خلال أسبوعين.
-- SCAMPER: فكرتان لكل حرف مع وصف التنفيذ الصحفي.</pre></div>
-</details>
-<div id="classic-wrap" class="desc">
-  <button id="toggleFrameworks" class="btn">الأطر الكلاسيكية</button>
-  <div id="frameworksList" style="display:none;">
-    <details>
-      <summary>5 Whys</summary>
-      <div class="desc">اسأل «لماذا؟» خمس مرات لاكتشاف الجذر.</div>
-      <div class="prompt" id="fw-5"><button class="copy" data-copy="fw-5">نسخ البرومبت</button><pre>طبّق 5 Whys على: [المشكلة].
-اعرض سلسلة الأسئلة ثم 3 حلول ممكنة.</pre></div>
-    </details>
-    <details>
-      <summary>SCAMPER</summary>
-      <div class="desc">استبدل، وادمج، وتكيّف، وعدّل، واستخدم، واستبعد، واعكس.</div>
-      <div class="prompt" id="fw-s"><button class="copy" data-copy="fw-s">نسخ البرومبت</button><pre>طوّر فكرة [الموضوع] باستخدام SCAMPER.
-قدّم اقتراحين لكل حرف.</pre></div>
-    </details>
-    <details>
-      <summary>قبعات التفكير الست</summary>
-      <div class="desc">أبيض=حقائق، أحمر=مشاعر، أسود=مخاطر، أصفر=فوائد، أخضر=إبداع، أزرق=تنظيم.</div>
-      <div class="prompt" id="fw-h"><button class="copy" data-copy="fw-h">نسخ البرومبت</button><pre>حلّل [القضية] بقبعات التفكير الست.
-خلاصة موجزة لكل قبعة.</pre></div>
-    </details>
-    <details>
-      <summary>الخرائط الذهنية</summary>
-      <div class="desc">ضع الفكرة في المركز ووسّع الفروع حتى تتضح الروابط.</div>
-      <div class="prompt" id="fw-m"><button class="copy" data-copy="fw-m">نسخ البرومبت</button><pre>ابنِ خريطة ذهنية لـ[الفكرة].
-اذكر الفروع الرئيسة و3 فروع فرعية لكل منها.</pre></div>
-    </details>
-    <details>
-      <summary>Starbursting</summary>
-      <div class="desc">ابدأ بنجمة الأسئلة الستة: من، ماذا، أين، متى، لماذا، كيف.</div>
-      <div class="prompt" id="fw-b"><button class="copy" data-copy="fw-b">نسخ البرومبت</button><pre>ولّد أسئلة Starbursting حول [الموضوع].
-قدّم إجابات مختصرة لأهم 10 أسئلة.</pre></div>
-    </details>
+<div class="fw-wrap" dir="rtl" lang="ar">
+  <div id="fw-list" class="fw-list show">
+    <!-- 1.1 لماذا 5 مرات -->
+    <article class="fw-card">
+      <details>
+        <summary>1.1 لماذا 5 مرات (5 Whys)</summary>
+        <p class="fw-meta"><b>فكرة الإطار:</b> اسأل “لماذا؟” حتى تصل لجذر المشكلة/الفرصة.</p>
+        <button class="copy-btn" data-copy="p-5whys">نسخ البرومبت</button>
+        <div id="p-5whys" class="prompt-box">
+حلّل المشكلة التالية بطريقة “لماذا 5 مرات”: [اكتب المشكلة]. اعطني سلسلة “لماذا→لأن” حتى الوصول لسبب جذري، ثم اقترح 3 حلول عملية قابلة للتنفيذ خلال أسبوعين.
+        </div>
+      </details>
+    </article>
+
+    <!-- 1.2 SCAMPER -->
+    <article class="fw-card">
+      <details>
+        <summary>1.2 SCAMPER</summary>
+        <p class="fw-meta"><b>الفكرة:</b> إعادة تخيّل الفكرة عبر سبعة اتجاهات.</p>
+        <button class="copy-btn" data-copy="p-scamper">نسخ البرومبت</button>
+        <div id="p-scamper" class="prompt-box">
+طبّق SCAMPER على [فكرتك/منتجك]. أعطني فكرتين لكل حرف (S,C,A,M,P,E,R) مع وصف موجز لكيفية التنفيذ.
+        </div>
+      </details>
+    </article>
+
+    <!-- 1.3 قبعات التفكير الست -->
+    <article class="fw-card">
+      <details>
+        <summary>1.3 قبعات التفكير الست</summary>
+        <p class="fw-meta">إدارة التفكير من 6 زوايا: حقائق، مشاعر، نقد، فوائد، ابتكار، تنظيم.</p>
+        <button class="copy-btn" data-copy="p-sixhats">نسخ البرومبت</button>
+        <div id="p-sixhats" class="prompt-box">
+قيّم موضوع: [العنوان]. طبّق قبعات التفكير الست بفقرة قصيرة لكل قبعة، ثم اختم بخطة 5 خطوات قابلة للتنفيذ.
+        </div>
+      </details>
+    </article>
+
+    <!-- 1.4 الخرائط الذهنية -->
+    <article class="fw-card">
+      <details>
+        <summary>1.4 الخرائط الذهنية</summary>
+        <p class="fw-meta"><b>الفكرة:</b> رسم شجري يبدأ من فكرة مركزية ويتفرّع.</p>
+        <button class="copy-btn" data-copy="p-mindmap">نسخ البرومبت</button>
+        <div id="p-mindmap" class="prompt-box">
+أنشئ لي خريطة ذهنية نصية لموضوع: [الموضوع]. ضع الفروع الرئيسية ثم فروعًا فرعية، واختم بخمس زوايا قصصية محتملة.
+        </div>
+      </details>
+    </article>
+
+    <!-- 1.5 العصف البرقي -->
+    <article class="fw-card">
+      <details>
+        <summary>1.5 العصف البرقي (Starbursting)</summary>
+        <p class="fw-meta"><b>الفكرة:</b> توليد أسئلة (ماذا/لماذا/كيف/من/أين/متى) بدل الإجابات.</p>
+        <button class="copy-btn" data-copy="p-starburst">نسخ البرومبت</button>
+        <div id="p-starburst" class="prompt-box">
+طبّق Starbursting على: [الفكرة]. أعطني 10 أسئلة “ماذا”، و10 “لماذا”، و10 “كيف”، و5 “من”، و5 “أين”، و5 “متى”، ثم رشّح أهم 8 أسئلة كبداية تحقيق صحفي.
+        </div>
+      </details>
+    </article>
   </div>
 </div>
+</details>
 </section>
 <section class="sec" id="s2">
 <details>
@@ -146,7 +169,9 @@ summary:hover .anchor{visibility:visible;}
 document.querySelectorAll('button[data-copy]').forEach(btn=>{
   btn.addEventListener('click',()=>{
     const id=btn.getAttribute('data-copy');
-    const text=document.querySelector('#'+id+' pre').innerText;
+    const target=document.getElementById(id);
+    const pre=target.querySelector('pre');
+    const text=pre?pre.innerText:target.textContent;
     navigator.clipboard.writeText(text).then(()=>{
       const old=btn.textContent;
       btn.textContent='تم النسخ ✅';
@@ -154,13 +179,6 @@ document.querySelectorAll('button[data-copy]').forEach(btn=>{
     });
   });
 });
-const fwBtn=document.getElementById('toggleFrameworks');
-if(fwBtn){
-  const fwList=document.getElementById('frameworksList');
-  fwBtn.addEventListener('click',()=>{
-    fwList.style.display=fwList.style.display==='none'?'block':'none';
-  });
-}
 const toggleBtn=document.getElementById('toggleAll');
 toggleBtn.addEventListener('click',()=>{
   const details=document.querySelectorAll('.sec details');


### PR DESCRIPTION
## Summary
- Replace legacy classic frameworks block with interactive details cards and copy buttons
- Add styles for new copy buttons and hidden prompt content
- Simplify clipboard script and remove obsolete toggle logic

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b16057b114832b87602e988a2af9ab